### PR TITLE
Added link to bash.md reference in documentation

### DIFF
--- a/TC_Powershell.md
+++ b/TC_Powershell.md
@@ -36,7 +36,8 @@ Everything is plain default, no specific settings needed to run a Load Impact pe
 
 We set up two build steps for this configuration, both do the same thing. Assuming you are running a TeamCity build agent on Windows you can run a PowerShell script to execute Load Impact Performance tests as part of your build.
 
-The other build step runs a Bash script as the build step using the built in SSH Exec runner.
+The other build step runs a Bash script as the build step using the built in SSH Exec runner. You can see how to do that in [teamcityloadimpacy/TC_bash.md]
+(https://github.com/loadimpact/teamcityloadimpact/blob/master/TC_bash.md)
 
 Both use [TeamCity Service Messages](https://confluence.jetbrains.com/display/TCD10/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ReportingTests) to communicate status and result to TeamCity.
 


### PR DESCRIPTION
Added second sentence and link to this paragraph: 

"The other build step runs a Bash script as the build step using the built in SSH Exec runner. You can see how to do that in teamcityloadimpacy/TC_bash.md."

We're going to use the Powershell doc on the marketing site's landing page, so I want to have a reference to the Bash resource on here, as well.

(Also, this is my first time working in github. It seems straightforward, but if I'm committing any type of faux pas when trying to suggest changes, please let me know.)